### PR TITLE
Improved support for TSL2561 lux sensor

### DIFF
--- a/src/Sensors/I2C/Loom_TSL2561.cpp
+++ b/src/Sensors/I2C/Loom_TSL2561.cpp
@@ -85,9 +85,13 @@ void Loom_TSL2561::measure()
 /////////////////////////////////////////////////////////////////////
 void Loom_TSL2561::package(JsonObject json)
 {
+    
+    int lux = inst_TSL2561->calculateLux(lightFull, lightIR);
+    
 	package_json(json, module_name, 
 		"IR",	lightIR,
-		"Full",	lightFull
+		"Full",	lightFull,
+        "Lux", lux
 	);
 }
 

--- a/src/Sensors/I2C/Loom_TSL2561.h
+++ b/src/Sensors/I2C/Loom_TSL2561.h
@@ -32,12 +32,12 @@ public:
 
 	/// TSL2561 module constructor
 	///
-	/// \param[in]	i2c_address				Set(Int) | <0x29> | {0x29, 0x39, 0x49} | I2C address
+	/// \param[in]	i2c_address				Set(Int) | <0x39> | {0x29, 0x39, 0x49} | I2C address
 	/// \param[in]	module_name				String | <"TSL2561"> | null | TSL2561 module name
 	/// \param[in]	gain					Set(Int) | <1> | {1, 16} | Gain level
 	/// \param[in]	resolution				Set(Int) | <3> | { 1("Low"), 2("Med"), 3("High") } | Resolution
 	Loom_TSL2561(
-			byte			i2c_address		= 0x29,
+			byte			i2c_address		= 0x39,
 			const char*		module_name		= "TSL2561",
 			int				gain			= 1,
 			int				resolution		= 3


### PR DESCRIPTION
Adding lux calculation in data packaging and switching default i2c address to the hardware default.