### PR TITLE
Multiplexer hotfix

### DIFF
--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -118,31 +118,36 @@ LoomI2CSensor* Loom_Multiplexer::generate_sensor_object(const byte i2c_address, 
 		case 0x1C : // MMA8451 / FXOS8700
 			if (i2c_0x1C == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
 			if (i2c_0x1C == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
+		break;
 
 		case 0x1D : // MMA8451 / FXOS8700
 			if (i2c_0x1D == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
 			if (i2c_0x1D == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
+		break;
 
 		case 0x1E : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
 		case 0x1F : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
-		case 0x20 : return new Loom_FXAS21002(i2c_address, port);	// FXAS21002
-		case 0x21 : return new Loom_FXAS21002(i2c_address, port);	// FXAS21002
+		case 0x20 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
+		case 0x21 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
 
 		case 0x29 : // TSL2561 / TSL2591
 			if (i2c_0x29 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
 			if (i2c_0x29 == I2C_Selection::L_TSL2591) return new Loom_TSL2591(i2c_address, port);	// TSL2591
-        case 0x36 : return new Loom_STEMMA(i2c_address, port); // STEMMA
+		break;
+
+		case 0x36 : return new Loom_STEMMA(i2c_address, port); // STEMMA
 		case 0x39 : return new Loom_TSL2561(i2c_address, port);	// TSL2561
 		case 0x40 : return new Loom_TMP007(i2c_address, port);	// TMP007
 		case 0x44 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
 		case 0x45 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
-
+		
 		case 0x49 : // TSL2561 / AS726X / AS7265X
 			if (i2c_0x49 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
 			if (i2c_0x49 == I2C_Selection::L_AS7262 ) return new Loom_AS7262(i2c_address, port);		// AS7262
 			if (i2c_0x49 == I2C_Selection::L_AS7263 ) return new Loom_AS7263(i2c_address, port);		// AS7263
 			if (i2c_0x49 == I2C_Selection::L_AS7265X) return new Loom_AS7265X(i2c_address, port);	// AS7265X
-			
+		break;
+
 		case 0x68 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
 		case 0x69 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
 		case 0x70 : return new Loom_MB1232(i2c_address, port);	// MB1232

--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -71,6 +71,7 @@ Loom_Multiplexer::Loom_Multiplexer(
 	, num_ports(num_ports)
 	, update_period(update_period)
 	, sensors(new LoomI2CSensor*[num_ports])
+	, control_port(0)
 {
 	// Begin I2C 
 	Wire.begin();
@@ -82,6 +83,8 @@ Loom_Multiplexer::Loom_Multiplexer(
 	for (auto i = 0; i < num_ports; i++) {
 		sensors[i] = nullptr;
 	}
+
+	control_address = get_i2c_on_port(control_port);
 
 	// Update sensor list and display   -- currently removed because Mux should be linked to DeviceManager before polling sensors
 	// refresh_sensors();
@@ -110,51 +113,56 @@ Loom_Multiplexer::~Loom_Multiplexer()
 ///////////////////////////////////////////////////////////////////////////////
 LoomI2CSensor* Loom_Multiplexer::generate_sensor_object(const byte i2c_address, const uint8_t port)
 {
-	switch (i2c_address) {
-		case 0x10 : return new Loom_ZXGesture(i2c_address, port);	// ZXGesture
-		case 0x11 : return new Loom_ZXGesture(i2c_address, port);	// ZXGesture
-		case 0x19 : return new Loom_LIS3DH(i2c_address, port);		// LIS3DH
+	if(i2c_address != control_address) {
+		LPrintln("Adding Sensor at address:", i2c_address);
+		switch (i2c_address) {
+			case 0x10 : return new Loom_ZXGesture(i2c_address, port);	// ZXGesture
+			case 0x11 : return new Loom_ZXGesture(i2c_address, port);	// ZXGesture
+			case 0x19 : return new Loom_LIS3DH(i2c_address, port);		// LIS3DH
 
-		case 0x1C : // MMA8451 / FXOS8700
-			if (i2c_0x1C == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
-			if (i2c_0x1C == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
-		break;
+			case 0x1C : // MMA8451 / FXOS8700
+				if (i2c_0x1C == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
+				if (i2c_0x1C == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
+			break;
 
-		case 0x1D : // MMA8451 / FXOS8700
-			if (i2c_0x1D == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
-			if (i2c_0x1D == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
-		break;
+			case 0x1D : // MMA8451 / FXOS8700
+				if (i2c_0x1D == I2C_Selection::L_MMA8451)  return new Loom_MMA8451(i2c_address, port);	// MMA8451
+				if (i2c_0x1D == I2C_Selection::L_FXOS8700) return new Loom_FXOS8700(i2c_address, port);	// FXOS8700
+			break;
 
-		case 0x1E : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
-		case 0x1F : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
-		case 0x20 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
-		case 0x21 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
+			case 0x1E : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
+			case 0x1F : return new Loom_FXOS8700(i2c_address, port);		// FXOS8700
+			case 0x20 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
+			case 0x21 : return new Loom_FXAS21002(i2c_address, port);		// FXAS21002
 
-		case 0x29 : // TSL2561 / TSL2591
-			if (i2c_0x29 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
-			if (i2c_0x29 == I2C_Selection::L_TSL2591) return new Loom_TSL2591(i2c_address, port);	// TSL2591
-		break;
+			case 0x29 : // TSL2561 / TSL2591
+				if (i2c_0x29 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
+				if (i2c_0x29 == I2C_Selection::L_TSL2591) return new Loom_TSL2591(i2c_address, port);	// TSL2591
+			break;
 
-		case 0x36 : return new Loom_STEMMA(i2c_address, port); // STEMMA
-		case 0x39 : return new Loom_TSL2561(i2c_address, port);	// TSL2561
-		case 0x40 : return new Loom_TMP007(i2c_address, port);	// TMP007
-		case 0x44 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
-		case 0x45 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
-		
-		case 0x49 : // TSL2561 / AS726X / AS7265X
-			if (i2c_0x49 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
-			if (i2c_0x49 == I2C_Selection::L_AS7262 ) return new Loom_AS7262(i2c_address, port);		// AS7262
-			if (i2c_0x49 == I2C_Selection::L_AS7263 ) return new Loom_AS7263(i2c_address, port);		// AS7263
-			if (i2c_0x49 == I2C_Selection::L_AS7265X) return new Loom_AS7265X(i2c_address, port);	// AS7265X
-		break;
+			case 0x36 : return new Loom_STEMMA(i2c_address, port); // STEMMA
+			case 0x39 : return new Loom_TSL2561(i2c_address, port);	// TSL2561
+			case 0x40 : return new Loom_TMP007(i2c_address, port);	// TMP007
+			case 0x44 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
+			case 0x45 : return new Loom_SHT31D(i2c_address, port);	// SHT31D
+			
+			case 0x49 : // TSL2561 / AS726X / AS7265X
+				if (i2c_0x49 == I2C_Selection::L_TSL2561) return new Loom_TSL2561(i2c_address, port);	// TSL2561
+				if (i2c_0x49 == I2C_Selection::L_AS7262 ) return new Loom_AS7262(i2c_address, port);		// AS7262
+				if (i2c_0x49 == I2C_Selection::L_AS7263 ) return new Loom_AS7263(i2c_address, port);		// AS7263
+				if (i2c_0x49 == I2C_Selection::L_AS7265X) return new Loom_AS7265X(i2c_address, port);	// AS7265X
+			break;
 
-		case 0x68 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
-		case 0x69 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
-		case 0x70 : return new Loom_MB1232(i2c_address, port);	// MB1232
-		case 0x76 : return new Loom_MS5803(i2c_address, port);	// MS5803
-		case 0x77 : return new Loom_MS5803(i2c_address, port);	// MS5803
+			case 0x68 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
+			case 0x69 : return new Loom_MPU6050(i2c_address, port);	// MPU6050
+			case 0x70 : return new Loom_MB1232(i2c_address, port);	// MB1232
+			case 0x76 : return new Loom_MS5803(i2c_address, port);	// MS5803
+			case 0x77 : return new Loom_MS5803(i2c_address, port);	// MS5803
 
-		default : return nullptr;
+			default : return nullptr;
+		}
+	} else {
+		return nullptr;
 	}
 }
 

--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -71,7 +71,7 @@ Loom_Multiplexer::Loom_Multiplexer(
 	, num_ports(num_ports)
 	, update_period(update_period)
 	, sensors(new LoomI2CSensor*[num_ports])
-	, control_port(0)
+	, control_port(num_ports)
 {
 	// Begin I2C 
 	Wire.begin();

--- a/src/Loom_Multiplexer.h
+++ b/src/Loom_Multiplexer.h
@@ -65,6 +65,9 @@ protected:
 	bool			dynamic_list;		///< Whether or not sensor list is dynamic (refresh sensor list periodically)
 	uint			update_period;		///< Interval to update sensor list at
 
+	uint8_t control_port;			//< Mux port to be used as a control
+	byte 		control_address;	//< Address at control_port to be ignored by refresh
+
 	unsigned long	last_update_time;	///< When the sensor list was last updated
 
 public:


### PR DESCRIPTION
Adds control port to prevent phantom instantiation on empty multiplexer ports due to external I2C ports.