### PR TITLE
Multiplexer hotfix

### DIFF
--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -71,7 +71,7 @@ Loom_Multiplexer::Loom_Multiplexer(
 	, num_ports(num_ports)
 	, update_period(update_period)
 	, sensors(new LoomI2CSensor*[num_ports])
-	, control_port(num_ports)
+	, control_port(num_ports-1)
 {
     
     // Begin I2C
@@ -356,9 +356,7 @@ bool Loom_Multiplexer::i2c_conflict(byte addr) const {
 }
 
 std::vector<byte> Loom_Multiplexer::find_i2c_conflicts() {
-    
-    LPrintln("Finding i2c conflicts dynamically.");
-    
+        
     tca_select(control_port);
     std::vector<byte> i2c_conflicts;
     byte addr;
@@ -370,8 +368,6 @@ std::vector<byte> Loom_Multiplexer::find_i2c_conflicts() {
         byte error = Wire.endTransmission();
 
         if (error == 0) {
-            LPrint("Found i2c conflict at address ");
-            LPrintln(addr);
             i2c_conflicts.push_back(addr);
         }
     }

--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -333,6 +333,8 @@ byte Loom_Multiplexer::get_i2c_on_port(const uint8_t port) const
 	for (auto j = 0; j < sizeof(known_addresses)/sizeof(known_addresses[0]); j++) {
 		
 		addr = known_addresses[j];
+        
+        // if this address is on the conflict list, skip it
         if (i2c_conflict(addr) || addr == this->i2c_address) {continue;}
         
 		Wire.beginTransmission(addr);
@@ -360,6 +362,7 @@ std::vector<byte> Loom_Multiplexer::find_i2c_conflicts() {
     tca_select(control_port);
     std::vector<byte> i2c_conflicts;
     byte addr;
+    // go through all the potentially conflicting sensors and find the ones that respond to blacklist them.
     for (auto j = 0; j < sizeof(known_addresses)/sizeof(known_addresses[0]); j++) {
         
         addr = known_addresses[j];

--- a/src/Loom_Multiplexer.cpp
+++ b/src/Loom_Multiplexer.cpp
@@ -102,7 +102,7 @@ Loom_Multiplexer::Loom_Multiplexer(JsonArrayConst p)
 Loom_Multiplexer::~Loom_Multiplexer() 
 {
 	// Free any sensors
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		if (sensors[i] != nullptr) {
 			delete sensors[i];
 		}
@@ -182,7 +182,7 @@ void Loom_Multiplexer::print_state() const
 	print_module_label();
 	LPrintln("Attached Sensors:");
 
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		LPrint("\tPort ", i, ": ");
 		if (sensors[i] != nullptr) {
 			LPrint_Dec_Hex(sensors[i]->get_i2c_address());
@@ -199,7 +199,7 @@ void Loom_Multiplexer::measure()
 {
 	refresh_sensors();
 
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		if (sensors[i] != nullptr) {
 			tca_select(i);
 			sensors[i]->measure();
@@ -210,7 +210,7 @@ void Loom_Multiplexer::measure()
 ///////////////////////////////////////////////////////////////////////////////
 void Loom_Multiplexer::print_measurements() const
 {
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		if (sensors[i] != nullptr) {
 			tca_select(i);
 			sensors[i]->print_measurements();
@@ -221,7 +221,7 @@ void Loom_Multiplexer::print_measurements() const
 ///////////////////////////////////////////////////////////////////////////////
 void Loom_Multiplexer::package(JsonObject json)
 {
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		if (sensors[i] != NULL) {
 			tca_select(i);
 			sensors[i]->package(json);
@@ -238,7 +238,7 @@ void Loom_Multiplexer::get_sensor_list(JsonObject json)
 	JsonObject list = json.createNestedObject("MuxSensors");
 
 	char tmp[3];
-	for (auto i = 0; i < num_ports; i++) {
+	for (auto i = 0U; i < num_ports; i++) {
 		if (sensors[i] != NULL) {
 			itoa(i, tmp, 10);
 			list[tmp] = sensors[i]->get_module_name();
@@ -330,12 +330,12 @@ byte Loom_Multiplexer::get_i2c_on_port(const uint8_t port) const
 
 	// Iterate through known addresses try to get confirmation from sensor
 	// for (auto addr = 1; addr <= 127; addr++) {
-	for (auto j = 0; j < sizeof(known_addresses)/sizeof(known_addresses[0]); j++) {
+	for (auto j = 0U; j < sizeof(known_addresses)/sizeof(known_addresses[0]); j++) {
 		
 		addr = known_addresses[j];
         
         // if this address is on the conflict list, skip it
-        if (i2c_conflict(addr) || addr == this->i2c_address) {continue;}
+        if (i2c_conflict(addr) || addr == this->i2c_address) { continue; }
         
 		Wire.beginTransmission(addr);
 		byte error = Wire.endTransmission();
@@ -347,13 +347,9 @@ byte Loom_Multiplexer::get_i2c_on_port(const uint8_t port) const
 }
 
 bool Loom_Multiplexer::i2c_conflict(byte addr) const {
-    for (byte conflict : i2c_conflicts) {
-        
-        if (conflict == addr) {
+    for (byte conflict : i2c_conflicts)
+        if (conflict == addr)
             return true;
-        }
-    }
-    
     return false;
 }
 

--- a/src/Loom_Multiplexer.h
+++ b/src/Loom_Multiplexer.h
@@ -72,7 +72,7 @@ protected:
 	uint8_t control_port;			//< Mux port to be used as a control
 
 	unsigned long	last_update_time;	///< When the sensor list was last updated
-    std::vector<byte> i2c_conflicts;
+    std::vector<byte> i2c_conflicts; ///< List of I2C address conflicts
     
 public:
 
@@ -181,8 +181,14 @@ private:
 	/// @return		The I2C address of sensor, 0x00 if no sensor found
 	byte			get_i2c_on_port(const uint8_t port) const;
     
+    /// Checks for an I2C conflict with this address
+    /// @param[in] address              The I2C address to check for conflicts
+    /// @return     True if there is a conflict, false otherwise
     bool i2c_conflict(byte address) const;
 
+    /// Find all I2C conflicts
+    /// Loops through known addresses and checks if they are being used outside of the multiplexer
+    /// @return     A vector of conflicting I2C addresses
     std::vector<byte> find_i2c_conflicts();
 };
 

--- a/src/Loom_Multiplexer.h
+++ b/src/Loom_Multiplexer.h
@@ -15,6 +15,10 @@
 #include "Loom_Module.h"
 #include "Sensors/I2C/Loom_I2C_Sensor.h"
 
+#undef min
+#undef max
+#include <vector>
+
 
 /// I2C Address Conflict Selection
 enum class I2C_Selection {
@@ -66,10 +70,10 @@ protected:
 	uint			update_period;		///< Interval to update sensor list at
 
 	uint8_t control_port;			//< Mux port to be used as a control
-	byte 		control_address;	//< Address at control_port to be ignored by refresh
 
 	unsigned long	last_update_time;	///< When the sensor list was last updated
-
+    std::vector<byte> i2c_conflicts;
+    
 public:
 
 //=============================================================================
@@ -176,7 +180,10 @@ private:
 	/// @param[in]	port	The port to get sensor address of
 	/// @return		The I2C address of sensor, 0x00 if no sensor found
 	byte			get_i2c_on_port(const uint8_t port) const;
+    
+    bool i2c_conflict(byte address) const;
 
+    std::vector<byte> find_i2c_conflicts();
 };
 
 


### PR DESCRIPTION
This pull request implements a dynamic blacklist of i2c addresses by checking all i2c addresses found when the multiplexer is set to an unused control port.
This should fix all phantom device problems. 

Where this will not fix problems is if you have a conflicted address on the multiplexer and on the device. If you do, then the multiplexer sensor will never get initialized because its address will be on the blacklist.