### PR TITLE
Add functions in LoRa to allow sending/recieving raw payloads

### DIFF
--- a/src/CommPlats/LoRa.cpp
+++ b/src/CommPlats/LoRa.cpp
@@ -144,4 +144,30 @@ bool Loom_LoRa::send_impl(JsonObject json, const uint8_t destination)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+bool Loom_LoRa::send_raw(uint8_t* bytes, const uint8_t len, const uint8_t destination) {
+	bool is_sent = manager.sendtoWait(bytes, len, destination);
 
+	print_module_label();
+	LPrintln("Send " , (is_sent) ? "successful" : "failed" );
+	signal_strength = driver.lastRssi();
+	driver.sleep();
+	return is_sent;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+bool Loom_LoRa::receive_blocking_raw(uint8_t* dest, const uint8_t maxlen, const uint max_wait_time) {
+	bool status;
+	uint8_t len = maxlen;
+	uint8_t from;
+	memset(dest, '\0', maxlen);
+	if (max_wait_time == 0)
+		status = manager.recvfromAck( dest, &len, &from );
+	else 
+		status = manager.recvfromAckTimeout( dest, &len, max_wait_time, &from );
+	
+	if (status)
+		signal_strength = driver.lastRssi();
+
+	driver.sleep();
+	return status;
+}

--- a/src/CommPlats/LoRa.h
+++ b/src/CommPlats/LoRa.h
@@ -70,6 +70,19 @@ protected:
 
 public:
 
+	/// Escape hatch for sending raw bytes
+	/// @param[in] raw		Bytes to send
+	/// @param[in] len		Number of bytes to send (MUST be less than 251)
+	/// @param[in] destination		Address of device to send to
+	/// @return True if packet sent successfully
+	bool send_raw(uint8_t* bytes, const uint8_t len, const uint8_t destination);
+
+	/// Escape hatch for receiving raw bytes
+	/// @param[out] dest	Pointer to byte array to store data
+	/// @param[in] maxlen	Maximum length of packet that can be recieved
+	/// @param[in] max_wait_time Maximum number of milliseconds to block for
+	bool receive_blocking_raw(uint8_t* dest, const uint8_t maxlen, const uint max_wait_time);
+
 //=============================================================================
 ///@name	CONSTRUCTORS / DESTRUCTOR
 /*@{*/ //======================================================================


### PR DESCRIPTION
This code allows a LoRa escape hatch for SitkaNet to transmit/recieve raw bytes, addressing https://github.com/OPEnSLab-OSU/Loom/issues/69 in that specific case.