### PR TITLE
RTC Examples Update

### DIFF
--- a/examples/Lab Examples/Hypnos_SD/Hypnos_SD.ino
+++ b/examples/Lab Examples/Hypnos_SD/Hypnos_SD.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board.
 

--- a/examples/Lab Examples/Hypnos_SD/config.h
+++ b/examples/Lab Examples/Hypnos_SD/config.h
@@ -17,7 +17,7 @@
 		},\
 		{\
 			'name':'DS3231',\
-			'params':'default'\
+			'params':[11,true,true]\
 		}\
 	]\
 }"

--- a/examples/Lab Examples/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
+++ b/examples/Lab Examples/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board
 // Deep sleep functionality.

--- a/examples/Lab Examples/Hypnos_SD_Sleep/config.h
+++ b/examples/Lab Examples/Hypnos_SD_Sleep/config.h
@@ -17,7 +17,7 @@
 		},\
 		{\
 			'name':'DS3231',\
-			'params':'default'\
+			'params':[11,true,true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/Hypnos_Sheets_LTE_Sleep.ino
+++ b/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/Hypnos_Sheets_LTE_Sleep.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is an example that demonstrates usage of the Hypnos board
 // Deep sleep functionality alongside with LTE and publishing to Google Sheets

--- a/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/config.h
+++ b/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/config.h
@@ -13,7 +13,7 @@
 		},\
 		{\
 			'name':'DS3231',\
-			'params':'default'\
+			'params':[11,true,true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/Lab Examples/SmartRockLoomSimple/SmartRockLoomSimple.ino
+++ b/examples/Lab Examples/SmartRockLoomSimple/SmartRockLoomSimple.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This example is the code used for the OPEnS Lab's Smart Rock
 

--- a/examples/Lab Examples/SmartRockLoomSimple/config.h
+++ b/examples/Lab Examples/SmartRockLoomSimple/config.h
@@ -7,7 +7,7 @@
 	'components':[\
 		{\
 			'name':'DS3231',\
-			'params':[11,true]\
+			'params':[11,true,true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/Lab Examples/SmartRock_Workshop/SmartRock_Workshop.ino
+++ b/examples/Lab Examples/SmartRock_Workshop/SmartRock_Workshop.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board
 // Deep sleep functionality.

--- a/examples/Lab Examples/SmartRock_Workshop/config.h
+++ b/examples/Lab Examples/SmartRock_Workshop/config.h
@@ -15,7 +15,7 @@
 		},\
 		{\
 			'name':'DS3231',\
-			'params':[11, true]\
+			'params':[11, true, true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/RTC/BasicRepeatingRTC_DS3231/BasicRepeatingRTC_DS3231.ino
+++ b/examples/RTC/BasicRepeatingRTC_DS3231/BasicRepeatingRTC_DS3231.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example of settings a repeating alarm with the DS3231 RTC.
 

--- a/examples/RTC/BasicRepeatingRTC_DS3231/config.h
+++ b/examples/RTC/BasicRepeatingRTC_DS3231/config.h
@@ -7,7 +7,7 @@
 	'components':[\
 		{\
 			'name':'DS3231',\
-			'params':[11,true,false]\
+			'params':[11,true,true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/RTC/BasicRepeatingRTC_PCF8523/BasicRepeatingRTC_PCF8523.ino
+++ b/examples/RTC/BasicRepeatingRTC_PCF8523/BasicRepeatingRTC_PCF8523.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example of settings a repeating alarm with the PCF8523 RTC.
 

--- a/examples/RTC/BasicRepeatingRTC_PCF8523/config.h
+++ b/examples/RTC/BasicRepeatingRTC_PCF8523/config.h
@@ -7,7 +7,7 @@
 	'components':[\
 		{\
 			'name':'PCF8523',\
-			'params':[11,true,false]\
+			'params':[11,true,true]\
 		},\
 		{\
 			'name':'InterruptManager',\

--- a/examples/RTC/DS3231_Customize_Time/DS3231_Customize_Time.ino
+++ b/examples/RTC/DS3231_Customize_Time/DS3231_Customize_Time.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a Basic example of RTC DS3231, but able to customize Time.
 

--- a/examples/RTC/PCF8523_Customize_Time/PCF8523_Customize_Time.ino
+++ b/examples/RTC/PCF8523_Customize_Time/PCF8523_Customize_Time.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a Basic example of RTC PCF8523, but able to customize Time.
 

--- a/examples/Sleep/Sleep/Sleep.ino
+++ b/examples/Sleep/Sleep/Sleep.ino
@@ -1,4 +1,12 @@
-///////////////////////////////////////////////////////////////////////////////
+///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
+// This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
+// You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
+// You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
+// The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
+// If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This example demonstrates how to put device to sleep and wake via
 // DS3231 RTC alarm connected to pin 12.

--- a/examples/Sleep/Sleep/config.h
+++ b/examples/Sleep/Sleep/config.h
@@ -10,7 +10,7 @@
   [\
     {\
       'name':'DS3231',\
-      'params':[11,true,false]\
+      'params':[11,true,true]\
     },\
     {\
       'name':'InterruptManager',\


### PR DESCRIPTION
Modifies Loom 3 examples that use the RTC so that they explicitly use the custom time setting for RTC and also so they include a comment instructing the user on what to do.
See: https://github.com/OPEnSLab-OSU/Loom/projects/2#card-79291544