### PR TITLE
Add Loom method to read serial number from Feather M0

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -68,6 +68,7 @@ Manager::Manager(
 	, interval(interval)
 {
 	snprintf(this->device_name, 20, "%s", device_name);
+	read_serial_no();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -748,4 +749,22 @@ bool Manager::check_serial_for_config()
 		return status;
 	}
 	return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void Manager::read_serial_no()
+{
+	// Serial numbers are made up of four words located at these specific registers (see datasheet)
+	uint32_t sn_words[4];
+	sn_words[0] = *(volatile uint32_t *)(0x0080A00C);
+	sn_words[1] = *(volatile uint32_t *)(0x0080A040);
+	sn_words[2] = *(volatile uint32_t *)(0x0080A044);
+	sn_words[3] = *(volatile uint32_t *)(0x0080A048);
+
+	// Take these raw values and convert them into a string of hex characters
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			sprintf(serial_no + (i * 8) + (j * 2), "%02X", (uint8_t)(sn_words[i] >> ((3 - j) * 8)));
+		}
+	}
 }

--- a/src/Manager.h
+++ b/src/Manager.h
@@ -32,6 +32,7 @@ class SleepManager;
 class InterruptManager;
 
 
+#define SERIAL_NO_LEN 	32		///< The length of the built-in serial number for Feather M0s
 #define SERIAL_BAUD		115200	///< Serial Baud Rate
 #define MAX_SERIAL_WAIT	20000	///< Maximum number of milliseconds to wait for user given 'begin_serial(true)'
 #define SD_CS			10		///< SD chip select used in parse_config_SD().
@@ -60,11 +61,12 @@ public:
 
 protected:
 
-	char		device_name[20];	///< The name of the device
-	uint8_t		instance;			///< The instance / channel ID within the subnet
+	char		device_name[20];		///< The name of the device
+	uint8_t		instance;				///< The instance / channel ID within the subnet
 
-	uint16_t	interval;			///< Default value for pause()
-									///< Used so that manager can control interval, rather than code in .ino
+	uint16_t	interval;				///< Default value for pause()
+										///< Used so that manager can control interval, rather than code in .ino
+	char serial_no[SERIAL_NO_LEN + 1]; 	///< Holds the serial number of the Feather M0 that Loom is running on
 
 	/// Device type (Hub / Node)
 	DeviceType	device_type;	// Maybe remove if using Hub, Node, and Repeater become subclasses of Manager
@@ -171,6 +173,9 @@ public:
 	/// Measure and package data.
 	/// Convenience function, current just calls measure then package
 	void		record() { measure(); package(); }
+
+	/// Returns the serial number of the Feather M0 Loom is running on.
+	const char* get_serial_no() { return serial_no; }
 
 	/// Package data of all modules into JsonObject and return
 	/// @return JsonObject of packaged data of enabled modules
@@ -450,6 +455,9 @@ private:
 
 	/// Used to add device info to data object
 	void add_device_ID_to_json(JsonObject json);
+
+	/// Reads the serial number from memory
+	void read_serial_no();
 
 	/// Free modules.
 	/// Used in destructor or when switching configuration


### PR DESCRIPTION
This modification gives the user the ability to access the unique serial-number built into Feather M0s for whatever purpose they need (see: [discussion](https://github.com/OPEnSLab-OSU/Loom/issues/181#issuecomment-1082189218)).

Overview of changes:
- Added new \#define for serial no. length at top of Module.h
- Added new protected character array to store serial no.
- Wrote private read_serial_no method that actually reads serial number in from registers and stores it in the array
- Added a call to read_serial_no in Module init
- Wrote a public get_serial_no method which simply returns the serial no. in the character array

Example use:
`LPrintln(Feather.get_serial_no()); // Prints the serial number`

Testing:
This was tested on a Feather M0 proto basic and Feather M0 WiFi but all Feather variants use the SAMD21 chip so this should work on all Feather variants.