### PR TITLE
Change conditional for determining when to print header rows to SD

### DIFF
--- a/examples/Lab Examples/Hypnos_SD/Hypnos_SD.ino
+++ b/examples/Lab Examples/Hypnos_SD/Hypnos_SD.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board.

--- a/examples/Lab Examples/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
+++ b/examples/Lab Examples/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board

--- a/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/Hypnos_Sheets_LTE_Sleep.ino
+++ b/examples/Lab Examples/Hypnos_Sheets_LTE_Sleep/Hypnos_Sheets_LTE_Sleep.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is an example that demonstrates usage of the Hypnos board

--- a/examples/Lab Examples/SmartRockLoomSimple/SmartRockLoomSimple.ino
+++ b/examples/Lab Examples/SmartRockLoomSimple/SmartRockLoomSimple.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This example is the code used for the OPEnS Lab's Smart Rock

--- a/examples/Lab Examples/SmartRock_Workshop/SmartRock_Workshop.ino
+++ b/examples/Lab Examples/SmartRock_Workshop/SmartRock_Workshop.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example that demonstrates usage of the Hypnos board

--- a/examples/RTC/BasicRepeatingRTC_DS3231/BasicRepeatingRTC_DS3231.ino
+++ b/examples/RTC/BasicRepeatingRTC_DS3231/BasicRepeatingRTC_DS3231.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example of settings a repeating alarm with the DS3231 RTC.

--- a/examples/RTC/BasicRepeatingRTC_PCF8523/BasicRepeatingRTC_PCF8523.ino
+++ b/examples/RTC/BasicRepeatingRTC_PCF8523/BasicRepeatingRTC_PCF8523.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'PCF8523',\                                                                                                                 //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a basic example of settings a repeating alarm with the PCF8523 RTC.

--- a/examples/RTC/DS3231_Customize_Time/DS3231_Customize_Time.ino
+++ b/examples/RTC/DS3231_Customize_Time/DS3231_Customize_Time.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a Basic example of RTC DS3231, but able to customize Time.

--- a/examples/RTC/PCF8523_Customize_Time/PCF8523_Customize_Time.ino
+++ b/examples/RTC/PCF8523_Customize_Time/PCF8523_Customize_Time.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'PCF8523',\                                                                                                                 //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is a Basic example of RTC PCF8523, but able to customize Time.

--- a/examples/Sleep/Sleep/Sleep.ino
+++ b/examples/Sleep/Sleep/Sleep.ino
@@ -1,11 +1,22 @@
 ///////////////////////////// IMPORTANT ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This example uses a config.h that allows you to set an initial custom time for the RTC (usually your local time).                      //
+// In the config file, you will notice this component:                                                                                    //
+//                                                                                                                                        //
+// {\                                                                                                                                     //
+//     'name':'DS3231',\                                                                                                                  //
+//     'params':[11,true,true]\                                                                                                           //
+// },\                                                                                                                                    //
+//                                                                                                                                        //
+// The first parameter is the timezone, a list of which can be found on the wiki at the link below.                                       //
+// The second parameter allows local time to be displayed alongside UTC time if set to true.                                              //
+// The third parameter allows you to enter a custom time using the serial monitor when the RTC is reset if set to true.                   //
+//                                                                                                                                        //
 // Upon sketch upload, click the magnifying glass in the top-right corner of the IDE to open the serial monitor.                          //
 // You will then be prompted to enter a year, month, day, hour, minute, and second.                                                       //
 // You can enter this information via an input field at the top of the serial monitor and hitting Enter or clicking Send.                 //
 // The time will be converted to UTC for display in the serial monitor, but the custom time will also appear in your log file on the SD.  //
 // If you are not prompted to enter a custom time, the RTC should be reset if it does not match the time you'd like.                      //
-// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Setting-Custom-RTC-Time                      //
+// Visit the Loom wiki for RTC reset instructions: https://github.com/OPEnSLab-OSU/Loom/wiki/Custom-RTC-Time                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This example demonstrates how to put device to sleep and wake via

--- a/src/LogPlats/SD.cpp
+++ b/src/LogPlats/SD.cpp
@@ -221,16 +221,16 @@ bool SD::save_json(JsonObject json, const char* name)
 	// Don't log if no data
 	if (contents.isNull()) return false;
 
-
-	// Create Header Rows
-	if ( file.curPosition() == 0) {
-
+	// Print the header rows if they have not already been printed
+	static bool headers_printed = false;
+	if (!headers_printed) {
 		// Create Header Row 1 (Categories)
 		_write_json_header_part1(file, dev_id, timestamp, contents);
 
 		// Create Header Row 2 (Column names)
 		_write_json_header_part2(file, dev_id, timestamp, contents);
 
+		headers_printed = true;
 	}
 
 	// Write data values


### PR DESCRIPTION
Currently, the SD module save_json method uses the cursor position in the file to determine when to print the header rows. It checks if the cursor is at position 0 (aka beginning of file, or file empty). The problem with this is it makes it very difficult for users to add custom data to the beginning of a log file, because if they do, the SD module will never write the header rows to the log file and it just looks ugly.

I was running into this issue when working on SmartRock and couldn't see a clean way to get the desired functionality without modifying Loom. All this pull request does is, instead of checking if the file is empty, just check if the headers have been written yet or not using a local static variable. This makes it easy for people to write custom data to the beginning of a log file without having to try to come up with some clever work-around.