### PR TITLE
Modify conditional for printing headers to SD in save_json

### DIFF
--- a/src/LogPlats/SD.cpp
+++ b/src/LogPlats/SD.cpp
@@ -221,16 +221,16 @@ bool SD::save_json(JsonObject json, const char* name)
 	// Don't log if no data
 	if (contents.isNull()) return false;
 
-
-	// Create Header Rows
-	if ( file.curPosition() == 0) {
-
+	// Print header rows only if they have not already been printed
+	static bool headers_printed = false;
+	if (!headers_printed) {
 		// Create Header Row 1 (Categories)
 		_write_json_header_part1(file, dev_id, timestamp, contents);
 
 		// Create Header Row 2 (Column names)
 		_write_json_header_part2(file, dev_id, timestamp, contents);
 
+		headers_printed = true;
 	}
 
 	// Write data values


### PR DESCRIPTION
Currently, the SD module save_json method uses the cursor position in the file to determine when to print the header rows. It checks if the cursor is at position 0 (aka beginning of file, or file empty). The problem with this is it makes it very difficult for users to add custom data to the beginning of a log file, because if they do, the SD module will never write the header rows to the log file and it just looks ugly.

I was running into this issue when working on SmartRock and couldn't see a clean way to get the desired functionality without modifying Loom. All this pull request does is, instead of checking if the file is empty, just check if the headers have been written yet or not using a local static variable. This makes it easy for people to write custom data to the beginning of a log file without having to try to come up with some clever work-around.