### PR TITLE
Implement accurate SD log file "last modified" date/time

### DIFF
--- a/src/LogPlats/SD.h
+++ b/src/LogPlats/SD.h
@@ -42,7 +42,7 @@ protected:
 
 		const byte	chip_select;		///< Chip select pin
 		char		filename[13];		///< String of file to write to if not filename explicitly provided (should not exceed 6 characters)
-		RTC*	RTC_Inst;			///< Pointer to an RTC object for timestamps
+		RTC*	RTC_Inst = NULL;			///< Pointer to an RTC object for timestamps
 
 		// SD_Version 		version;
 		// byte 			reset_pin;

--- a/src/RTC/RTC.h
+++ b/src/RTC/RTC.h
@@ -175,6 +175,14 @@ public:
 	/// @param[out]	buf		Buffer to fill
 	void			get_weekday(char* buf);
 
+	/// Get if using local time
+	/// @return	Is using local time
+	bool is_using_local_time() { return use_local_time; }
+
+	/// Get DateTime in local time
+	/// @return	DateTime object in local time
+	DateTime get_local_rtc() { this->local_rtc(); return local_time; }
+
 //=============================================================================
 ///@name	MISCELLANEOUS
 /*@{*/ //======================================================================


### PR DESCRIPTION
Log files now have a more accurate "last modified" date/time. Used to be they would have none so it would default to the year 2000. Modification added as per Gurpreet's request.